### PR TITLE
Exit with error code when snippet not found

### DIFF
--- a/bin/tuttest
+++ b/bin/tuttest
@@ -36,8 +36,8 @@ if __name__ == "__main__":
                     # select snippet by number
                     code.append(list(snippets.values())[int(c[1:])].text.strip())
                 else:
-                    # no match, add ad hoc code as separate line
-                    code.append(c.strip())
+                    # no match, exit with error code
+                    exit(1)
 
     if args.single_command:
         code = [';'.join(code)]


### PR DESCRIPTION
Currently tuttest doesn't exit with error code when given snippet name wasn't found. For example:

    $ tuttest example-file.rst non-existing-snippet`
    non-existing-snippet

And `$?` is set to `0`.

This PR changes it so that when given snippet name wasn't found, tuttest exits with error code `1`.