### PR TITLE
Add wildcard support for snippet names

### DIFF
--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -12,5 +12,13 @@ diff <(tuttest test/test.md unnamed2) <(tuttest README.md test-unnamed2)
 diff <(tuttest test/test.md unnamed2 --prefix-lines-with "docker exec -t test bash -c") <(tuttest README.md test-prefix)
 diff <(tuttest test/test.md bash-tutorial,unnamed2 --prefix-lines-with "docker exec -t test bash -c" --single-command) <(tuttest README.md single-command)
 
+# wildcard testing
+diff <(tuttest test/test.md 'unnamed?') <(tuttest test/test.md unnamed0,unnamed2)
+diff <(tuttest test/test.rst 'unnamed?') <(tuttest test/test.rst unnamed0,unnamed2)
+diff <(tuttest test/test-wildcard.md '[bd]ash*') <(tuttest test/test-wildcard.md bash-tutorial,dash-tutorial-duplicate)
+diff <(tuttest test/test-wildcard.rst '[bd]ash*') <(tuttest test/test-wildcard.rst bash-tutorial,dash-tutorial-duplicate)
+diff <(tuttest test/test-wildcard.md '[!d]ash*') <(tuttest test/test-wildcard.md bash-tutorial)
+diff <(tuttest test/test-wildcard.rst '[!d]ash*') <(tuttest test/test-wildcard.rst bash-tutorial)
+
 echo "All tests successfully passed!"
 

--- a/bin/tuttest
+++ b/bin/tuttest
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from tuttest import get_snippets
+import fnmatch
 
 if __name__ == "__main__":
     import sys
@@ -23,8 +24,11 @@ if __name__ == "__main__":
             code.append(snippets[s].text.strip())
     else:
         commands = args.commands.split(',')
-
+        commands_filter = []
         for c in commands:
+            commands_filter.extend(fnmatch.filter(snippets, c))
+
+        for c in commands_filter:
             if c in snippets:
                 # name matches, add snippet code
                 code.append(snippets[c].text.strip())

--- a/test/test-wildcard.md
+++ b/test/test-wildcard.md
@@ -1,0 +1,19 @@
+```
+echo "This is the first unnamed snippet"
+```
+
+<!-- name="bash-tutorial" -->
+```
+echo "This is a named snippet"
+printf "1 + 2 = %d\n" $((1+2))
+```
+
+```
+echo "This is the second unnamed snippet"
+```
+
+<!-- name="dash-tutorial-duplicate" -->
+```
+echo "This is a named snippet duplicate"
+printf "1 + 2 = %d\n" $((1+2))
+```

--- a/test/test-wildcard.rst
+++ b/test/test-wildcard.rst
@@ -1,0 +1,19 @@
+.. code-block:: bash
+
+   echo "This is the first unnamed snippet"
+
+.. code-block:: bash
+   :name: bash-tutorial
+
+   echo "This is a named snippet"
+   printf "1 + 2 = %d\n" $((1+2))
+
+.. code-block:: bash
+
+   echo "This is the second unnamed snippet"
+
+.. code-block:: bash
+   :name: dash-tutorial-duplicate
+
+   echo "This is a named snippet duplicate"
+   printf "1 + 2 = %d\n" $((1+2))


### PR DESCRIPTION
For example, you can select all snippets with names that start with `my-example` with:

    tuttest README.rst 'my-example*'

Standard shell-style wildcards are supported: `*`, `?`, `[abc]`, `[!abc]`.