### PR TITLE
Added possibility to filter snippets by language from CLI command

### DIFF
--- a/.github/workflows/build-static.sh
+++ b/.github/workflows/build-static.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Builds tuttest command-line tool as a static binary
+
+set -e
+
+SCRIPT_DIR=$(dirname $(realpath $0))
+
+cd $SCRIPT_DIR/../../
+
+if [[ -n "$SKIP_DEPS_INSTALL" ]]
+then
+    echo "Skipping installation of static build dependencies"
+else
+    echo "Installing dependencies for static build..."
+    apt -qqy update
+    apt -qqy install patchelf build-essential python3-pip git zlib1g-dev python3-setuptools python3-venv python3-wheel
+
+    git clone https://github.com/pyinstaller/pyinstaller.git
+
+    cd pyinstaller/bootloader
+    CC="gcc -no-pie" python3 waf configure all
+    cd -
+
+    cd pyinstaller
+    pip3 install .
+    cd -
+
+    pip3 install staticx
+fi
+
+echo "Building the static binary for tuttest"
+
+pip3 install .
+
+pyinstaller --collect-all tuttest -F bin/tuttest
+staticx dist/tuttest tuttest_static
+chmod 755 tuttest_static

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,21 +29,10 @@ jobs:
     runs-on: ubuntu-18.04
     needs: [test]
     steps:
-    - uses: actions/checkout@v2
-    - name: Install build tools
-      run: |
-        sudo apt -qqy update && sudo apt -qqy install patchelf build-essential python3-pip git zlib1g-dev python3-setuptools python3-venv python3-wheel
-        git clone https://github.com/pyinstaller/pyinstaller.git
-        cd pyinstaller/bootloader && CC="gcc -no-pie" python3 waf configure all && cd -
-        cd pyinstaller && sudo python3 setup.py install && cd -
-        sudo pip3 install staticx
-    - name: Install tuttest dependencies
-      run: python setup.py egg_info && pip3 install -r *.egg-info/requires.txt
-    - name: Build static binary
-      run: |
-        pyinstaller -F bin/tuttest
-        staticx dist/tuttest tuttest_static
-    - uses: actions/upload-artifact@v2
+    - uses: actions/checkout@v3
+    - name: Build tuttest static binary
+      run: sudo .github/workflows/build-static.sh
+    - uses: actions/upload-artifact@v3
       with:
         name: tuttest_static
         path: tuttest_static

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8]
+        python-version: ["3.8", "3.10"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Display Python version
@@ -26,7 +26,7 @@ jobs:
     - name: Run tests
       run: bash .github/workflows/test.sh
   build-static:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: [test]
     steps:
     - uses: actions/checkout@v3

--- a/bin/tuttest
+++ b/bin/tuttest
@@ -14,11 +14,14 @@ if __name__ == "__main__":
 
     parser.add_argument('--prefix-lines-with', metavar='prefix', type=str, help='string to prefix each command with')
     parser.add_argument('--single-command', action='store_true', help='executes all snippets in single command')
+    parser.add_argument('--language', type=str, metavar='lang', help='selects all snippets for a given language')
 
     args = parser.parse_args()
 
     code = []
     snippets = get_snippets(args.filename)
+    if args.language:
+        snippets = {name: snippet for name, snippet in snippets.items() if snippet.lang == args.language}
     if not args.commands:
         for s in snippets:
             code.append(snippets[s].text.strip())


### PR DESCRIPTION
This PR adds `--language` option allowing to filter code snippets in the file by language, e.g.:

```bash
tuttest --language bash README.md
```

will filter out all snippets with `bash` language.